### PR TITLE
bindgen: Use -fshort-enums to coerce Clang to behave in the same manner as ARM GCC

### DIFF
--- a/src/build/source/local_sdk.rs
+++ b/src/build/source/local_sdk.rs
@@ -134,7 +134,8 @@ pub fn try_build() -> Result {
 
 		// ARM toolchain
 		builder = builder.blocklist_file("stdlib.h")
-		                 .clang_args(&["--include-directory", &toolchain.join("include").display().to_string()]);
+		                 .clang_args(&["--include-directory", &toolchain.join("include").display().to_string()])
+                                 .clang_arg("-fshort-enums");
 
 
 		// specifically for the target:

--- a/src/error/fs.rs
+++ b/src/error/fs.rs
@@ -10,8 +10,8 @@ use crate::ffi::FS_Error;
 pub type Status = FS_Error;
 
 
-impl const From<i32> for Status {
-	fn from(v: i32) -> Self {
+impl const From<i8> for Status {
+	fn from(v: i8) -> Self {
 		match v {
 			0 => Self::FSE_OK,
 			1 => Self::FSE_NOT_READY,
@@ -28,8 +28,8 @@ impl const From<i32> for Status {
 	}
 }
 
-impl const From<i32> for Error {
-	fn from(v: i32) -> Self { unsafe { core::mem::transmute(v) } }
+impl const From<i8> for Error {
+	fn from(v: i8) -> Self { unsafe { core::mem::transmute(v) } }
 }
 
 impl const From<Error> for Status {
@@ -68,7 +68,7 @@ impl const FromResidual for Status {
 	}
 }
 
-#[repr(i32)]
+#[repr(i8)]
 #[derive(Debug, Clone)]
 pub enum Error {
 	#[doc = "FS not ready"]


### PR DESCRIPTION
**Summary**
Enum types being generated by bindgen currently appear to be annotated with #[repr(u32)] regardless of whether the enum's data type can be smaller. 

Normally, this would be the expected behaviour - however, using the GCC-based ARM toolchain bundled with FBT, it appears that short enums (-fshort-enums) are used. This can cause misaligned reads on variables and struct fields from the Rust-side as a result.

As an example, this is how InputEvent is represented in Flipper's firmware.elf (both for compact and debug builds - so the optimisation flag appears to be irrelevant):
```
(gdb) ptype /o InputEvent
type = struct {
/*      0      |       4 */    uint32_t sequence;
/*      4      |       1 */    InputKey key;
/*      5      |       1 */    InputType type;
/* XXX  2-byte padding   */

                               /* total size (bytes):    8 */
                             }
```

Where InputKey and InputType are treated as u8 types, versus the same structure's representation under flipper0-sys's bindgen:
```
#[repr(u32)]
#[non_exhaustive]
#[doc = " Input Types"]
#[doc = " Some of them are physical events and some logical"]
#[derive(Clone, Hash, PartialEq, Eq)]
pub enum InputType {
        #[doc = "< Press event, emitted after debounce"]
        InputTypePress = 0,
        #[doc = "< Release event, emitted after debounce"]
        InputTypeRelease = 1,
        #[doc = "< Short event, emitted after InputTypeRelease done withing INPUT_LONG_PRESS interval"]
        InputTypeShort = 2,
        #[doc = "< Long event, emmited after INPUT_LONG_PRESS interval, asynchronouse to InputTypeRelease"]
        InputTypeLong = 3,
        #[doc = "< Repeat event, emmited with INPUT_REPEATE_PRESS period after InputTypeLong event"]
        InputTypeRepeat = 4,
        #[doc = "< Special value for exceptional"]
        InputTypeMAX = 5,
}
#[repr(u32)]
#[non_exhaustive]
#[derive(Clone, Hash, PartialEq, Eq)]
pub enum InputKey {
        InputKeyUp = 0,
        InputKeyDown = 1,
        InputKeyRight = 2,
        InputKeyLeft = 3,
        InputKeyOk = 4,
        InputKeyBack = 5,
        #[doc = "< Special value"]
        InputKeyMAX = 6,
}
#[doc = " Input Event, dispatches with FuriPubSub"]
#[repr(C)]
pub struct InputEvent {
        pub sequence: u32,
        pub key: InputKey,
        pub type_: InputType,
}
```

This PR sets the -fshort-enums flag in the local SDK build process such that the behaviour is the same across both toolchains. I am fairly new to Rust, so any comments / changes around this are very much welcome.